### PR TITLE
checkBanned and checkMuted

### DIFF
--- a/anvil-api-core/src/main/java/org/anvilpowered/anvil/api/core/coremember/repository/CoreMemberRepository.java
+++ b/anvil-api-core/src/main/java/org/anvilpowered/anvil/api/core/coremember/repository/CoreMemberRepository.java
@@ -182,6 +182,89 @@ public interface CoreMemberRepository<
     CompletableFuture<Boolean> unBanIpAddress(String ipAddress);
 
     /**
+     * Verifies whether the provided {@link CoreMember} is in fact
+     * banned.
+     *
+     * <p>
+     * A user is only banned if {@link CoreMember#isBanned()} is
+     * true and {@link CoreMember#getBanEndUtc()} is in the future.
+     * </p>
+     *
+     * <p>
+     * This method checks both {@link CoreMember#isBanned()} and
+     * {@link CoreMember#getBanEndUtc()} and sets the member's
+     * ban status accordingly.
+     * </p>
+     *
+     * @param coreMember {@link CoreMember} to verify ban for
+     * @return {@code true} if user is verified to be banned, otherwise {@code false}
+     */
+    boolean checkBanned(CoreMember<?> coreMember);
+
+    /**
+     * Verifies whether the {@link CoreMember} matching the provided
+     * {@link TKey} is in fact banned.
+     *
+     * <p>
+     * A user is only banned if {@link CoreMember#isBanned()} is
+     * true and {@link CoreMember#getBanEndUtc()} is in the future.
+     * </p>
+     *
+     * <p>
+     * This method checks both {@link CoreMember#isBanned()} and
+     * {@link CoreMember#getBanEndUtc()} and sets the member's
+     * ban status accordingly.
+     * </p>
+     *
+     * @param id {@link TKey} id of member to verify ban for
+     * @return {@link CompletableFuture} wrapped {@link Boolean}.
+     * {@code true} if user is verified to be banned, otherwise {@code false}
+     */
+    CompletableFuture<Boolean> checkBanned(TKey id);
+
+    /**
+     * Verifies whether the {@link CoreMember} matching the provided
+     * {@link UUID} userUUID is in fact banned.
+     *
+     * <p>
+     * A user is only banned if {@link CoreMember#isBanned()} is
+     * true and {@link CoreMember#getBanEndUtc()} is in the future.
+     * </p>
+     *
+     * <p>
+     * This method checks both {@link CoreMember#isBanned()} and
+     * {@link CoreMember#getBanEndUtc()} and sets the member's
+     * ban status accordingly.
+     * </p>
+     *
+     * @param userUUID {@link UUID} userUUID of member to verify ban for
+     * @return {@link CompletableFuture} wrapped {@link Boolean}.
+     * {@code true} if user is verified to be banned, otherwise {@code false}
+     */
+    CompletableFuture<Boolean> checkBannedForUser(UUID userUUID);
+
+    /**
+     * Verifies whether the {@link CoreMember} matching the provided
+     * {@link String} userName is in fact banned.
+     *
+     * <p>
+     * A user is only banned if {@link CoreMember#isBanned()} is
+     * true and {@link CoreMember#getBanEndUtc()} is in the future.
+     * </p>
+     *
+     * <p>
+     * This method checks both {@link CoreMember#isBanned()} and
+     * {@link CoreMember#getBanEndUtc()} and sets the member's
+     * ban status accordingly.
+     * </p>
+     *
+     * @param userName {@link String} userUUID of member to verify ban for
+     * @return {@link CompletableFuture} wrapped {@link Boolean}.
+     * {@code true} if user is verified to be banned, otherwise {@code false}
+     */
+    CompletableFuture<Boolean> checkBannedForUser(String userName);
+
+    /**
      * Updates the properties {@code muteEndUtc}, {@code muteReason}
      * and sets {@code muted} to {@code true} for the document
      * whose id matches the provided {@link TKey}
@@ -275,6 +358,89 @@ public interface CoreMemberRepository<
      * true if successful, otherwise false
      */
     CompletableFuture<Boolean> unMuteIpAddress(String ipAddress);
+
+    /**
+     * Verifies whether the provided {@link CoreMember} is in fact
+     * muted.
+     *
+     * <p>
+     * A user is only muted if {@link CoreMember#isMuted()} is
+     * true and {@link CoreMember#getMuteEndUtc()} is in the future.
+     * </p>
+     *
+     * <p>
+     * This method checks both {@link CoreMember#isMuted()} and
+     * {@link CoreMember#getMuteEndUtc()} and sets the member's
+     * mute status accordingly.
+     * </p>
+     *
+     * @param coreMember {@link CoreMember} to verify mute for
+     * @return {@code true} if user is verified to be muted, otherwise {@link false}
+     */
+    boolean checkMuted(CoreMember<?> coreMember);
+
+    /**
+     * Verifies whether the {@link CoreMember} matching the provided
+     * {@link TKey} is in fact muted.
+     *
+     * <p>
+     * A user is only muted if {@link CoreMember#isMuted()} is
+     * true and {@link CoreMember#getMuteEndUtc()} is in the future.
+     * </p>
+     *
+     * <p>
+     * This method checks both {@link CoreMember#isMuted()} and
+     * {@link CoreMember#getMuteEndUtc()} and sets the member's
+     * mute status accordingly.
+     * </p>
+     *
+     * @param id {@link TKey} id of member to verify mute for
+     * @return {@link CompletableFuture} wrapped {@link Boolean}.
+     * {@code true} if user is verified to be muted, otherwise {@link false}
+     */
+    CompletableFuture<Boolean> checkMuted(TKey id);
+
+    /**
+     * Verifies whether the {@link CoreMember} matching the provided
+     * {@link UUID} userUUID is in fact muted.
+     *
+     * <p>
+     * A user is only muted if {@link CoreMember#isMuted()} is
+     * true and {@link CoreMember#getMuteEndUtc()} is in the future.
+     * </p>
+     *
+     * <p>
+     * This method checks both {@link CoreMember#isMuted()} and
+     * {@link CoreMember#getMuteEndUtc()} and sets the member's
+     * mute status accordingly.
+     * </p>
+     *
+     * @param userUUID {@link UUID} userUUID of member to verify mute for
+     * @return {@link CompletableFuture} wrapped {@link Boolean}.
+     * {@code true} if user is verified to be muted, otherwise {@link false}
+     */
+    CompletableFuture<Boolean> checkMutedForUser(UUID userUUID);
+
+    /**
+     * Verifies whether the {@link CoreMember} matching the provided
+     * {@link String} userName is in fact muted.
+     *
+     * <p>
+     * A user is only muted if {@link CoreMember#isMuted()} is
+     * true and {@link CoreMember#getMuteEndUtc()} is in the future.
+     * </p>
+     *
+     * <p>
+     * This method checks both {@link CoreMember#isMuted()} and
+     * {@link CoreMember#getMuteEndUtc()} and sets the member's
+     * mute status accordingly.
+     * </p>
+     *
+     * @param userUUID {@link UUID} userUUID of member to verify mute for
+     * @return {@link CompletableFuture} wrapped {@link Boolean}.
+     * {@code true} if user is verified to be muted, otherwise {@link false}
+     */
+    CompletableFuture<Boolean> checkMutedForUser(String userUUID);
 
     /**
      * Updates the property {@code nickName} for the

--- a/anvil-bungee/src/main/java/org/anvilpowered/anvil/bungee/listeners/BungeePlayerListener.java
+++ b/anvil-bungee/src/main/java/org/anvilpowered/anvil/bungee/listeners/BungeePlayerListener.java
@@ -29,9 +29,6 @@ import org.anvilpowered.anvil.api.core.coremember.CoreMemberManager;
 import org.anvilpowered.anvil.api.core.model.coremember.CoreMember;
 import org.anvilpowered.anvil.api.core.plugin.PluginMessages;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-
 public class BungeePlayerListener implements Listener {
 
     @Inject
@@ -54,10 +51,10 @@ public class BungeePlayerListener implements Listener {
                 return;
             }
             CoreMember<?> coreMember = optionalMember.get();
-            if (coreMember.isBanned() && coreMember.getBanEndUtc().isAfter(OffsetDateTime.now(ZoneOffset.UTC).toInstant())) {
-                player.disconnect(pluginMessages.getBanMessage(coreMember.getBanReason(), coreMember.getBanEndUtc()));
-            } else if (coreMember.isBanned()) {
-                coreMemberManager.getPrimaryComponent().unBanUser(player.getUniqueId());
+            if (coreMemberManager.getPrimaryComponent().checkBanned(coreMember)) {
+                player.disconnect(
+                    pluginMessages.getBanMessage(coreMember.getBanReason(), coreMember.getBanEndUtc())
+                );
             }
         }).join();
     }
@@ -72,12 +69,12 @@ public class BungeePlayerListener implements Listener {
             if (!optionalMember.isPresent()) {
                 return;
             }
-            CoreMember<?> member = optionalMember.get();
-            if (member.isMuted() && member.getMuteEndUtc().isAfter(OffsetDateTime.now(ZoneOffset.UTC).toInstant())) {
+            CoreMember<?> coreMember = optionalMember.get();
+            if (coreMemberManager.getPrimaryComponent().checkMuted(coreMember)) {
                 event.setCancelled(true);
-                player.sendMessage(pluginMessages.getMuteMessage(member.getMuteReason(), member.getMuteEndUtc()));
-            } else if (member.isMuted()) {
-                coreMemberManager.getPrimaryComponent().unMuteUser(player.getUniqueId());
+                player.sendMessage(
+                    pluginMessages.getMuteMessage(coreMember.getMuteReason(), coreMember.getMuteEndUtc())
+                );
             }
         }).join();
     }

--- a/anvil-common/src/main/java/org/anvilpowered/anvil/common/coremember/repository/CommonCoreMemberRepository.java
+++ b/anvil-common/src/main/java/org/anvilpowered/anvil/common/coremember/repository/CommonCoreMemberRepository.java
@@ -23,6 +23,8 @@ import org.anvilpowered.anvil.base.repository.BaseRepository;
 import org.anvilpowered.anvil.api.core.coremember.repository.CoreMemberRepository;
 import org.anvilpowered.anvil.api.core.model.coremember.CoreMember;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -46,5 +48,55 @@ public abstract class CommonCoreMemberRepository<
     @Override
     public CompletableFuture<Optional<CoreMember<TKey>>> getOneOrGenerateForUser(UUID userUUID, String userName, String ipAddress) {
         return getOneOrGenerateForUser(userUUID, userName, ipAddress, new boolean[]{false, false, false, false, false, false, false, false});
+    }
+
+    @Override
+    public boolean checkBanned(CoreMember<?> coreMember) {
+        if (coreMember.isBanned() && coreMember.getBanEndUtc().isAfter(OffsetDateTime.now(ZoneOffset.UTC).toInstant())) {
+            return true;
+        } else if (coreMember.isBanned()) {
+            unBanUser(coreMember.getUserUUID());
+        }
+        return false;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> checkBanned(TKey id) {
+        return getOne(id).thenApplyAsync(o -> o.map(this::checkBanned).orElse(false));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> checkBannedForUser(UUID userUUID) {
+        return getOneForUser(userUUID).thenApplyAsync(o -> o.map(this::checkBanned).orElse(false));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> checkBannedForUser(String userName) {
+        return getOneForUser(userName).thenApplyAsync(o -> o.map(this::checkBanned).orElse(false));
+    }
+
+    @Override
+    public boolean checkMuted(CoreMember<?> coreMember) {
+        if (coreMember.isMuted() && coreMember.getMuteEndUtc().isAfter(OffsetDateTime.now(ZoneOffset.UTC).toInstant())) {
+            return true;
+        } else if (coreMember.isMuted()) {
+            unMuteUser(coreMember.getUserUUID());
+        }
+        return false;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> checkMuted(TKey id) {
+        return getOne(id).thenApplyAsync(o -> o.map(this::checkMuted).orElse(false));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> checkMutedForUser(UUID userUUID) {
+        return getOneForUser(userUUID).thenApplyAsync(o -> o.map(this::checkMuted).orElse(false));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> checkMutedForUser(String userName) {
+        return getOneForUser(userName).thenApplyAsync(o -> o.map(this::checkMuted).orElse(false));
     }
 }

--- a/anvil-velocity/src/main/java/org/anvilpowered/anvil/velocity/listeners/VelocityPlayerListener.java
+++ b/anvil-velocity/src/main/java/org/anvilpowered/anvil/velocity/listeners/VelocityPlayerListener.java
@@ -19,7 +19,6 @@
 package org.anvilpowered.anvil.velocity.listeners;
 
 import com.google.inject.Inject;
-import com.velocitypowered.api.event.ResultedEvent;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.LoginEvent;
 import com.velocitypowered.api.event.player.PlayerChatEvent;
@@ -28,9 +27,6 @@ import net.kyori.text.TextComponent;
 import org.anvilpowered.anvil.api.core.coremember.CoreMemberManager;
 import org.anvilpowered.anvil.api.core.model.coremember.CoreMember;
 import org.anvilpowered.anvil.api.core.plugin.PluginMessages;
-
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 
 public class VelocityPlayerListener {
 
@@ -52,11 +48,11 @@ public class VelocityPlayerListener {
             if (!optionalMember.isPresent()) {
                 return;
             }
-            CoreMember<?> member = optionalMember.get();
-            if (member.isBanned() && member.getBanEndUtc().isAfter(OffsetDateTime.now(ZoneOffset.UTC).toInstant())) {
-                event.setResult(ResultedEvent.ComponentResult.denied(pluginMessages.getBanMessage(member.getBanReason(), member.getBanEndUtc())));
-            } else if (member.isBanned()) {
-                coreMemberManager.getPrimaryComponent().unBanUser(player.getUniqueId());
+            CoreMember<?> coreMember = optionalMember.get();
+            if (coreMemberManager.getPrimaryComponent().checkBanned(coreMember)) {
+                player.disconnect(
+                    pluginMessages.getBanMessage(coreMember.getBanReason(), coreMember.getBanEndUtc())
+                );
             }
         }).join();
     }
@@ -71,12 +67,12 @@ public class VelocityPlayerListener {
             if (!optionalMember.isPresent()) {
                 return;
             }
-            CoreMember<?> member = optionalMember.get();
-            if (member.isMuted() && member.getMuteEndUtc().isAfter(OffsetDateTime.now(ZoneOffset.UTC).toInstant())) {
+            CoreMember<?> coreMember = optionalMember.get();
+            if (coreMemberManager.getPrimaryComponent().checkMuted(coreMember)) {
                 event.setResult(PlayerChatEvent.ChatResult.denied());
-                player.sendMessage(pluginMessages.getMuteMessage(member.getMuteReason(), member.getMuteEndUtc()));
-            } else if (member.isMuted()) {
-                coreMemberManager.getPrimaryComponent().unMuteUser(player.getUniqueId());
+                player.sendMessage(
+                    pluginMessages.getMuteMessage(coreMember.getMuteReason(), coreMember.getMuteEndUtc())
+                );
             }
         }).join();
     }


### PR DESCRIPTION
This PR adds the methods `checkBanned()` and `checkMuted()` to the CoreMemberRepository. Since `CoreMember#isBanned` and `CoreMember#isMuted` do not always reflect the actual ban and mute statuses. To do a full check, a comparison of `CoreMember#getBanEndUtc` and `CoreMember#getMuteEndUtc` is required.